### PR TITLE
Add user task association and tests

### DIFF
--- a/backend/app/models/user.rb
+++ b/backend/app/models/user.rb
@@ -1,4 +1,5 @@
 class User < ApplicationRecord
+    has_many :tasks, dependent: :destroy
     has_secure_password
 
     VALID_PASSWORD_REGEX = /\A(?=.*[a-z])(?=.*[A-Z])(?=.*\d).{8,}\z/

--- a/backend/test/fixtures/tasks.yml
+++ b/backend/test/fixtures/tasks.yml
@@ -1,15 +1,17 @@
 # Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
 
 one:
-  title: MyString
-  description: MyText
+  title: Buy groceries
+  description: Purchase milk and eggs
   due_date: 2025-06-29 00:54:40
-  column: MyString
-  done_at: 2025-06-29 00:54:40
+  column: todo
+  done_at: 
+  user: alice
 
 two:
-  title: MyString
-  description: MyText
+  title: Finish report
+  description: Complete the quarterly report
   due_date: 2025-06-29 00:54:40
-  column: MyString
-  done_at: 2025-06-29 00:54:40
+  column: in_progress
+  done_at: 
+  user: alice

--- a/backend/test/fixtures/users.yml
+++ b/backend/test/fixtures/users.yml
@@ -1,0 +1,11 @@
+# Read about fixtures at https://api.rubyonrails.org/classes/ActiveRecord/FixtureSet.html
+
+alice:
+  name: Alice Example
+  email: alice@example.com
+  password_digest: <%= BCrypt::Password.create('Password1') %>
+
+bob:
+  name: Bob Example
+  email: bob@example.com
+  password_digest: <%= BCrypt::Password.create('Password1') %>

--- a/backend/test/models/user_test.rb
+++ b/backend/test/models/user_test.rb
@@ -1,0 +1,10 @@
+require "test_helper"
+
+class UserTest < ActiveSupport::TestCase
+  test "has many tasks" do
+    user = users(:alice)
+
+    assert_equal 2, user.tasks.size
+    assert_equal [tasks(:one), tasks(:two)], user.tasks.order(:id)
+  end
+end


### PR DESCRIPTION
## Summary
- add the tasks association on the user model with dependent destroy
- add user and task fixtures plus a user model test to cover task listings

## Testing
- bin/rails test test/models/user_test.rb *(fails: Ruby 3.4.4 available but Gemfile requires 3.3.0)*

------
https://chatgpt.com/codex/tasks/task_e_68e088452e1c8331a4ba60ffb2a43a4b