### PR TITLE
Fix tasks show action lookup and add controller tests

### DIFF
--- a/backend/app/controllers/api/v1/tasks_controller.rb
+++ b/backend/app/controllers/api/v1/tasks_controller.rb
@@ -5,8 +5,13 @@ class Api::V1::TasksController < ApplicationController
     end
 
     def show
-        task = @current_user.tasks.build(task_params)
-        task ? render(json: task) : render(json: { error: 'Task not found' }, status: :not_found)
+        task = @current_user.tasks.find_by(id: params[:id])
+
+        if task.nil?
+            render json: { error: 'Task not found or not authorized' }, status: :not_found
+        else
+            render json: task
+        end
     end
     
     def create

--- a/backend/test/controllers/api/v1/tasks_controller_test.rb
+++ b/backend/test/controllers/api/v1/tasks_controller_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class Api::V1::TasksControllerTest < ActionDispatch::IntegrationTest
+  setup do
+    @user = users(:alice)
+    @task = tasks(:one)
+  end
+
+  test "should show task for current user" do
+    get api_v1_task_url(@task), headers: auth_headers(@user)
+
+    assert_response :success
+
+    body = JSON.parse(response.body)
+    assert_equal @task.id, body["id"]
+    assert_equal @task.title, body["title"]
+  end
+
+  test "should return 404 when task not found" do
+    get api_v1_task_url(-1), headers: auth_headers(@user)
+
+    assert_response :not_found
+
+    body = JSON.parse(response.body)
+    assert_equal "Task not found or not authorized", body["error"]
+  end
+
+  private
+
+  def auth_headers(user)
+    token = JWT.encode({ user_id: user.id }, jwt_secret, "HS256")
+    { "Authorization" => "Bearer #{token}" }
+  end
+
+  def jwt_secret
+    Rails.application.secrets.secret_key_base || Rails.application.secret_key_base
+  end
+end


### PR DESCRIPTION
## Summary
- update the tasks#show action to load an existing task and reuse the not-found response
- add controller integration tests covering the successful show response and 404 handling

## Testing
- bundle exec rails test test/controllers/api/v1/tasks_controller_test.rb *(fails: bundler requires Ruby 3.3.0 but environment provides Ruby 3.4.4)*

------
https://chatgpt.com/codex/tasks/task_e_68e088df1fc88331a5ada91ce0e99294